### PR TITLE
Update tag version of osixia/openldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap:1.1.6
+FROM osixia/openldap:1.2.2
 MAINTAINER Johan Smits
 
 ADD bootstrap /container/service/slapd/assets/config/bootstrap


### PR DESCRIPTION
osixia/openldap actual version is 1.2.2.
So you should update the tag in the Dockerfile.